### PR TITLE
Add Seq Serilog sink

### DIFF
--- a/ShopkeepersQuiz.Api/ShopkeepersQuiz.Api.csproj
+++ b/ShopkeepersQuiz.Api/ShopkeepersQuiz.Api.csproj
@@ -29,6 +29,8 @@
     <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
   </ItemGroup>
 

--- a/ShopkeepersQuiz.Api/Startup.cs
+++ b/ShopkeepersQuiz.Api/Startup.cs
@@ -43,13 +43,11 @@ namespace ShopkeepersQuiz.Api
 			{
 				app.UseDeveloperExceptionPage();
 
-				Log.Logger.Information("Environment variables:" 
+				Log.Logger.Debug("Environment variables:" 
 					+ Environment.NewLine 
 					+ string.Join(Environment.NewLine + "\t", Configuration.AsEnumerable().Select(x => x.Key + ": " + x.Value))
 					+ Environment.NewLine);
 			}
-
-			app.UseHttpsRedirection();
 
 			app.UseRouting();
 
@@ -59,6 +57,8 @@ namespace ShopkeepersQuiz.Api
 			{
 				endpoints.MapControllers();
 			});
+
+			app.UseSerilogRequestLogging();
 
 			EnsureDatabaseMigrated(app);
 		}

--- a/ShopkeepersQuiz.Api/appsettings.Development.json
+++ b/ShopkeepersQuiz.Api/appsettings.Development.json
@@ -6,6 +6,11 @@
     "ApplicationDatabase": "Server=.\\SQLEXPRESS;Database=ShopkeepersQuiz;Trusted_Connection=True;"
   },
   "Serilog": {
+    "Using": [
+      "Serilog.Sinks.Console",
+      "Serilog.Sinks.File",
+      "Serilog.Sinks.Seq"
+    ],
     "MinimumLevel": "Debug",
     "WriteTo": [
       {
@@ -17,6 +22,10 @@
           "path": "logs/application-.log",
           "rollingInterval": "Day"
         }
+      },
+      {
+        "Name": "Seq",
+        "Args": { "serverUrl": "http://localhost:5341" }
       }
     ]
   }

--- a/ShopkeepersQuiz.Api/appsettings.json
+++ b/ShopkeepersQuiz.Api/appsettings.json
@@ -14,6 +14,7 @@
     "ApplicationDatabase": ""
   },
   "Serilog": {
+    "Using": [ "Serilog.Sinks.Console" ],
     "MinimumLevel": "Information",
     "WriteTo": [
       {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,21 +6,44 @@ services:
     ports:
       - "5555:80"
     environment:
-      Serilog__MinimumLevel: "Debug"
+      ASPNETCORE_ENVIRONMENT: "Development"
       QuestionSettings__PreloadedQuestionsCount: 5
       QuestionSettings__QuestionTimeSeconds: 10
       QuestionSettings__AnswerTimeSeconds: 5
       QuestionSettings__IncorrectAnswersGenerated: 5
       ScraperSettings__RunEvery: "0 4 ? * THU"
       ConnectionStrings__ApplicationDatabase: "Server=database,1433;Database=ShopkeepersQuiz;User Id=sa;Password=SeCR3T_P@55w0rD;"
+      Serilog__MinimumLevel: "Information"
+      Serilog__Using__1: "Serilog.Sinks.Seq"
+      Serilog__WriteTo__1__Name: "Seq"
+      Serilog__WriteTo__1__Args__serverUrl: "http://seq:80"
     depends_on:
       - database
+      - seq
 
   database:
     container_name: shopkeepers-quiz-db
     image: "mcr.microsoft.com/mssql/server"
-    ports: 
+    user: root
+    ports:
       - "11433:1433"
+    volumes:
+      - "db-data:/var/opt/mssql"
     environment:
       SA_PASSWORD: "SeCR3T_P@55w0rD"
       ACCEPT_EULA: "Y"
+
+  seq:
+    container_name: shopkeepers-quiz-logs
+    image: "datalust/seq:latest"
+    ports:
+      - 5341:80
+    volumes:
+      - "seq-data:/data"
+    environment:
+      ACCEPT_EULA: "Y"
+
+volumes:
+  db-data:
+  seq-data:
+  


### PR DESCRIPTION
Allows Serilog to log to a docker container running Seq.

This will allow easier access and visibility of logs when the API is in production.