### PR TITLE
Fix release build naming

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,4 +1,4 @@
-name: CI Build
+name: Release Build
 
 on:
   create:


### PR DESCRIPTION
## Description
Changes the release build name to be "Release Build".

## Motivation and Context
The release build was accidentally named "CI Build" which is already used by the CI build.

## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Will be tested on GitHub as part of the first release.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.