### PR TITLE
Add Swagger UI via Swashbuckle

### DIFF
--- a/ShopkeepersQuiz.Api/Controllers/QuestionsController.cs
+++ b/ShopkeepersQuiz.Api/Controllers/QuestionsController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using ShopkeepersQuiz.Api.Mappers;
 using ShopkeepersQuiz.Api.Services.Questions;
 using System.Linq;
@@ -8,6 +9,7 @@ namespace ShopkeepersQuiz.Api.Controllers
 {
     [ApiController]
     [Route("[controller]")]
+    [Produces("application/json")]
     public class QuestionsController : Controller
     {
         private readonly IQuestionService _questionService;
@@ -18,6 +20,8 @@ namespace ShopkeepersQuiz.Api.Controllers
         }
 
         [HttpGet]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> GetNextQuestions()
         {
             var result = await _questionService.GetQuestionQueue();

--- a/ShopkeepersQuiz.Api/Properties/launchSettings.json
+++ b/ShopkeepersQuiz.Api/Properties/launchSettings.json
@@ -19,7 +19,6 @@
     "ShopkeepersQuiz.Api": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "weatherforecast",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/ShopkeepersQuiz.Api/ShopkeepersQuiz.Api.csproj
+++ b/ShopkeepersQuiz.Api/ShopkeepersQuiz.Api.csproj
@@ -6,6 +6,11 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Remove="Migrations\20200801164908_InitialMigration.cs" />
     <Compile Remove="Migrations\20200801164908_InitialMigration.Designer.cs" />
@@ -31,6 +36,7 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
   </ItemGroup>
 

--- a/ShopkeepersQuiz.Api/Startup.cs
+++ b/ShopkeepersQuiz.Api/Startup.cs
@@ -13,7 +13,9 @@ using ShopkeepersQuiz.Api.Services.Questions;
 using ShopkeepersQuiz.Api.Services.Questions.Generation;
 using ShopkeepersQuiz.Api.Services.Scrapers;
 using System;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 
 namespace ShopkeepersQuiz.Api
 {
@@ -34,11 +36,21 @@ namespace ShopkeepersQuiz.Api
 
 			services.AddMemoryCache();
 
+			services.AddSwaggerGen(config =>
+			{
+				var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+				var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
+				config.IncludeXmlComments(xmlPath);
+			});
+
 			RegisterDependencyInjection(services);
 		}
 
 		public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 		{
+			string appName = Configuration.GetValue("Name", "Shopkeeper's Quiz API");
+			string appVersion = Configuration.GetValue("Version", "0.0.0");
+
 			if (env.IsDevelopment())
 			{
 				app.UseDeveloperExceptionPage();
@@ -57,6 +69,14 @@ namespace ShopkeepersQuiz.Api
 			{
 				endpoints.MapControllers();
 			});
+
+			app.UseSwagger();
+			app.UseSwaggerUI(config =>
+			{
+				config.SwaggerEndpoint("/swagger/v1/swagger.json", $"{appName} v{appVersion}");
+				config.RoutePrefix = string.Empty;
+			});
+
 
 			app.UseSerilogRequestLogging();
 


### PR DESCRIPTION
Adds Swagger to the app, to easily browse the OpenAPI v3 specification of the API.

## Description
Adds the Swashbuckle.AspNetCore package to the project to generate and expose a Swagger UI endpoint.

## Motivation and Context
This makes it easier to test the API once deployed, and allows me to instantly see whether the app is online at the correct URL.

## Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Tested locally.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.