### PR TITLE
Add workaround for branch filter for release workflow

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,14 +1,15 @@
 name: Release Build
 
 on:
-  create:
-    branches: 
-      - release/[0-9]+.[0-9]+.[0-9]+
+  create
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # Only run if the build is a release branch
+    if: ${{ contains(github.ref, 'refs/heads/release/') }}
 
+    runs-on: ubuntu-latest
+    
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
## Description
Adds a workaround for filtering branches for the `on: create` trigger.

For more information see: https://github.community/t/trigger-job-on-branch-created/16878/5

## Motivation and Context
Currently the branch filter doesn't work as expected - this kind of branch filter is only available for `push` and `pull_request` triggers, not for the `create` trigger that is being used in this release workflow YAML file. This workaround works in a similar way and will be good enough until GitHub add first-party support for the functionality.

## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Hopefully there shouldn't be any more Release Build runs once this PR is merged into master.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.