### PR TITLE
Add endpoint to retrieve the correct answer

### DIFF
--- a/ShopkeepersQuiz.Api/Controllers/QuestionsController.cs
+++ b/ShopkeepersQuiz.Api/Controllers/QuestionsController.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using ShopkeepersQuiz.Api.Mappers;
+using ShopkeepersQuiz.Api.Models.Messages;
 using ShopkeepersQuiz.Api.Services.Questions;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -26,6 +28,20 @@ namespace ShopkeepersQuiz.Api.Controllers
         {
             var result = await _questionService.GetQuestionQueue();
             return Ok(result.Select(x => x.MapToDto()));
+        }
+
+        [HttpGet("{queueEntryId}/answers")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public IActionResult GetAnswerForQueueEntry(Guid queueEntryId)
+        {
+            var result = _questionService.GetPreviousQueueEntryAnswer(queueEntryId);
+
+            return result.Match<IActionResult>(
+                answerDto => Ok(answerDto),
+                notFound => NotFound(ResponseMessages.Errors.AnwerNotFound),
+                notAvailable => NotFound(ResponseMessages.Errors.AnwerNotAvailableYet));
         }
     }
 }

--- a/ShopkeepersQuiz.Api/Dtos/AnswerDto.cs
+++ b/ShopkeepersQuiz.Api/Dtos/AnswerDto.cs
@@ -1,4 +1,4 @@
-﻿namespace ShopkeepersQuiz.Api.Dtos.Queues
+﻿namespace ShopkeepersQuiz.Api.Dtos
 {
 	public class AnswerDto
 	{

--- a/ShopkeepersQuiz.Api/Dtos/QueueEntryDto.cs
+++ b/ShopkeepersQuiz.Api/Dtos/QueueEntryDto.cs
@@ -8,6 +8,10 @@ namespace ShopkeepersQuiz.Api.Dtos.Queues
 	{
 		public Guid Id { get; set; }
 
+		public DateTime StartTimeUtc { get; set; }
+
+		public DateTime EndTimeUtc { get; set; }
+
 		public string Key { get; set; }
 
 		public QuestionType Type { get; set; }

--- a/ShopkeepersQuiz.Api/Mappers/AnswerMapper.cs
+++ b/ShopkeepersQuiz.Api/Mappers/AnswerMapper.cs
@@ -1,4 +1,4 @@
-﻿using ShopkeepersQuiz.Api.Dtos.Queues;
+﻿using ShopkeepersQuiz.Api.Dtos;
 using ShopkeepersQuiz.Api.Models.Answers;
 
 namespace ShopkeepersQuiz.Api.Mappers

--- a/ShopkeepersQuiz.Api/Mappers/QueueEntryMapper.cs
+++ b/ShopkeepersQuiz.Api/Mappers/QueueEntryMapper.cs
@@ -24,6 +24,8 @@ namespace ShopkeepersQuiz.Api.Mappers
 			return new QueueEntryDto()
 			{
 				Id = entity.Id,
+				StartTimeUtc = entity.StartTimeUtc,
+				EndTimeUtc = entity.EndTimeUtc,
 				Key = entity.Question.Key,
 				Type = entity.Question.Type,
 				Question = entity.Question.Text,

--- a/ShopkeepersQuiz.Api/Models/Answers/AnswerNotAvailableYet.cs
+++ b/ShopkeepersQuiz.Api/Models/Answers/AnswerNotAvailableYet.cs
@@ -1,0 +1,10 @@
+﻿namespace ShopkeepersQuiz.Api.Models.Answers
+{
+	/// <summary>
+	/// Struct to mark that the given <see cref="Answer"/> for a previous <see cref="Models.Queues.QueueEntry"/>
+	/// is not yet available for users to view because the timer hasn't ended yet.
+	/// </summary>
+	public struct AnswerNotAvailableYet
+	{
+	}
+}

--- a/ShopkeepersQuiz.Api/Models/Cache/CacheKeys.cs
+++ b/ShopkeepersQuiz.Api/Models/Cache/CacheKeys.cs
@@ -1,4 +1,6 @@
-﻿namespace ShopkeepersQuiz.Api.Models.Cache
+﻿using System;
+
+namespace ShopkeepersQuiz.Api.Models.Cache
 {
 	/// <summary>
 	/// Constants for storing and retrieving data from the memory cache.
@@ -6,5 +8,6 @@
 	public static class CacheKeys
 	{
 		public static string QuestionQueue = nameof(QuestionQueue);
+		public static string PreviousQueueEntry(Guid queueId) => $"{nameof(PreviousQueueEntry)}__{queueId:N}";
 	}
 }

--- a/ShopkeepersQuiz.Api/Models/Messages/ResponseMessages.cs
+++ b/ShopkeepersQuiz.Api/Models/Messages/ResponseMessages.cs
@@ -7,6 +7,9 @@
 			public static string GenericError = "An error has occurred.";
 			public static string GenericNotFound = "The given resource could not be found.";
 			public static string GenericInvalidOperation = "The given operation could not be completed.";
+
+			public static string AnwerNotFound = "The requested answer could not be found.";
+			public static string AnwerNotAvailableYet = "The requested answer is not available yet, please try again later.";
 		}
 	}
 }

--- a/ShopkeepersQuiz.Api/Services/Questions/IQuestionService.cs
+++ b/ShopkeepersQuiz.Api/Services/Questions/IQuestionService.cs
@@ -1,4 +1,9 @@
-﻿using ShopkeepersQuiz.Api.Models.Queues;
+﻿using OneOf;
+using OneOf.Types;
+using ShopkeepersQuiz.Api.Dtos;
+using ShopkeepersQuiz.Api.Models.Answers;
+using ShopkeepersQuiz.Api.Models.Queues;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -10,5 +15,11 @@ namespace ShopkeepersQuiz.Api.Services.Questions
 		/// Gets the next few questions in the queue.
 		/// </summary>
 		public Task<IEnumerable<QueueEntry>> GetQuestionQueue();
+
+		/// <summary>
+		/// Gets the correct <see cref="AnswerDto"/> for a previous <see cref="QueueEntry"/>.
+		/// </summary>
+		/// <param name="queueEntryId">The ID of the <see cref="QueueEntry"/>.</param>
+		public OneOf<AnswerDto, NotFound, AnswerNotAvailableYet> GetPreviousQueueEntryAnswer(Guid queueEntryId);
 	}
 }

--- a/ShopkeepersQuiz.Api/Services/Questions/QuestionService.cs
+++ b/ShopkeepersQuiz.Api/Services/Questions/QuestionService.cs
@@ -76,9 +76,9 @@ namespace ShopkeepersQuiz.Api.Services.Questions
 			foreach (var queueEntry in questionQueue)
 			{
 				string cacheKey = CacheKeys.PreviousQueueEntry(queueEntry.Id);
-				DateTimeOffset cacheDuration = DateTime.UtcNow.AddSeconds((double)_questionSettings.QuestionTimeSeconds * 10);
+				DateTimeOffset cacheExpiry = queueEntry.EndTimeUtc.AddSeconds((double)_questionSettings.QuestionTimeSeconds * 5);
 
-				_cache.Set(cacheKey, queueEntry, cacheDuration);
+				_cache.Set(cacheKey, queueEntry, cacheExpiry);
 			}
 
 			return questionQueue;

--- a/ShopkeepersQuiz.Api/ShopkeepersQuiz.Api.csproj
+++ b/ShopkeepersQuiz.Api/ShopkeepersQuiz.Api.csproj
@@ -12,6 +12,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="logs\**" />
+    <Content Remove="logs\**" />
+    <EmbeddedResource Remove="logs\**" />
+    <None Remove="logs\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Remove="Migrations\20200801164908_InitialMigration.cs" />
     <Compile Remove="Migrations\20200801164908_InitialMigration.Designer.cs" />
     <Compile Remove="Migrations\20200803183105_AddHeroesAbilitiesAndItems.cs" />
@@ -30,6 +37,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.3" />
+    <PackageReference Include="OneOf" Version="2.1.155" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />

--- a/ShopkeepersQuiz.Api/Startup.cs
+++ b/ShopkeepersQuiz.Api/Startup.cs
@@ -32,6 +32,8 @@ namespace ShopkeepersQuiz.Api
 		{
 			services.AddControllers();
 
+			services.AddRouting(config => config.LowercaseUrls = true);
+
 			services.AddDbContext<ApplicationDbContext>();
 
 			services.AddMemoryCache();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
Adds a new endpoint and service method to the QuestionService to allow users to make an API call to retrieve the answer of a previous question once the question has finished. This has a 2s grace period to allow for mismatched clock synchronisation between clients and the server, where a client thinks the question has finished but on the server the question is still running.

This also exposes the start and end time of a question, as I forgot to expose this on the `/questions` endpoint previously.

## Motivation and Context
Without this no one can know if they answered correctly or not, as answers are hidden in the `/questions` endpoint to prevent cheating (even though it doesn't matter if someone cheats).

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Local testing via Swagger.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.