### PR TITLE
Fix extract release version step in release build

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -16,8 +16,8 @@ jobs:
     - name: Extract release version
       shell: bash
       run: |
-        [[ ${GITHUB_REF#refs/heads/} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || (echo "Invalid branch name format!" && exit 1);
-        echo "##[set-output name=version;]$(echo ${GITHUB_REF#refs/heads/})"
+        [[ ${GITHUB_REF#refs/heads/release/} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || (echo "Invalid branch name format!" && exit 1);
+        echo "##[set-output name=version;]$(echo ${GITHUB_REF#refs/heads/release})"
       id: extract_version
 
     - uses: microsoft/variable-substitution@v1 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
Fixes an issue where "release" wasn't being removed from the branch name when extracting the release build version. It previously only removed `refs/heads/` but now removes `refs/heads/release/`.

## Motivation and Context
This should allow release builds to be run by creating a release branch.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
It will be tested when I create a release branch 😁 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.