### PR TITLE
Echo release build version for debugging, fix path to appsettings.json

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -17,12 +17,13 @@ jobs:
       shell: bash
       run: |
         [[ ${GITHUB_REF#refs/heads/release/} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || (echo "Invalid branch name format!" && exit 1);
+        echo "Setting release version variable to: ${GITHUB_REF#refs/heads/release}"
         echo "##[set-output name=version;]$(echo ${GITHUB_REF#refs/heads/release})"
       id: extract_version
 
     - uses: microsoft/variable-substitution@v1 
       with:
-        files: 'appsettings.json'
+        files: 'ShopkeepersQuiz.Api/appsettings.json'
       env:
         Version: ${{ steps.extract_version.outputs.version }}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
Fixes a couple of issues with the release build:
- now `echo`s the release build version in the extract release version step for debugging
- fixes the path to _appsettings.json_ to look under the right directory

## Motivation and Context
To fix the release build so I can do a release.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Tested with the upcoming release.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.