### PR TITLE
Use PAT secret for GitHub CR access

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -30,8 +30,7 @@ jobs:
     - name: Build & publish docker image
       uses: matootie/github-docker@v3.1.0
       with:
-        accessToken: ${{ secrets.GITHUB_TOKEN  }}
-        imageName: "shopkeepers-quiz-api"
+        accessToken: ${{ secrets.CONTAINERREGISTRYACCESSTOKEN  }}
         tag: |
           latest
           ${{ steps.extract_version.outputs.version }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
Updates the release build to use a PAT from my account to access the repo's GitHub container registry.

## Motivation and Context
Docker build step was failing as it was being denied access to the repo.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
n/a

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.