### PR TITLE
Hotfix/scraper switch bug

### DIFF
--- a/ShopkeepersQuiz.Api/BackgroundServices/QuestionDataBackgroundService.cs
+++ b/ShopkeepersQuiz.Api/BackgroundServices/QuestionDataBackgroundService.cs
@@ -124,7 +124,7 @@ namespace ShopkeepersQuiz.Api.BackgroundServices
 			}
 			catch (Exception ex)
 			{
-				_logger.Error($"Unhandled {ex.GetType().Name} thrown in background service: {ex.Message}{Environment.NewLine}{ex.StackTrace}");
+				_logger.Error(ex, $"Unhandled {ex.GetType().Name} thrown in background service.");
 			}
 			finally
 			{

--- a/ShopkeepersQuiz.Api/Services/Questions/Generation/CooldownQuestionGenerator.cs
+++ b/ShopkeepersQuiz.Api/Services/Questions/Generation/CooldownQuestionGenerator.cs
@@ -189,17 +189,11 @@ namespace ShopkeepersQuiz.Api.Services.Questions.Generation
 				{
 					int val when minimumValue <= 5 => _randomHelper.ChooseRandomNumberBetween(-1 * val + 1, 6),
 					_ when minimumValue <= 12 => _randomHelper.ChooseRandomNumberBetween(-3, 8),
-					int valOver20By5 when minimumValue % 5 == 0 && minimumValue > 20 => valOver20By5 switch
-					{
-						_ when minimumValue <= 30 => _randomHelper.ChooseRandomNumberBetween(-2, 2) * 5,
-						_ when minimumValue <= 50 => _randomHelper.ChooseRandomNumberBetween(-4, 3) * 5,
-						_ when minimumValue <= 80 => _randomHelper.ChooseRandomNumberBetween(-6, 4) * 5,
-					},
-					int valBy2 when minimumValue % 2 == 0 => valBy2 switch
-					{
-						_ when minimumValue <= 30 => _randomHelper.ChooseRandomNumberBetween(-4, 7) * 2,
-						_ when minimumValue <= 60 => _randomHelper.ChooseRandomNumberBetween(-5, 10) * 2,
-					},
+					_ when minimumValue % 5 == 0 && minimumValue <= 30 => _randomHelper.ChooseRandomNumberBetween(-2, 2) * 5,
+					_ when minimumValue % 5 == 0 && minimumValue <= 50 => _randomHelper.ChooseRandomNumberBetween(-4, 3) * 5,
+					_ when minimumValue % 5 == 0 && minimumValue <= 80 => _randomHelper.ChooseRandomNumberBetween(-6, 4) * 5,
+					_ when minimumValue % 2 == 0 && minimumValue <= 30 => _randomHelper.ChooseRandomNumberBetween(-4, 7) * 2,
+					_ when minimumValue % 2 == 0 && minimumValue <= 60 => _randomHelper.ChooseRandomNumberBetween(-5, 10) * 2,
 					_ when minimumValue <= 20 => _randomHelper.ChooseRandomNumberBetween(-3, 5) * 2,
 					_ when minimumValue <= 40 => _randomHelper.ChooseRandomNumberBetween(-5, 7) * 2,
 					_ => _randomHelper.ChooseRandomNumberBetween(-10, 10) * 2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
The CooldownQuestionGenerator was failing due to a bad switch statement. The new C# 8 switch statement requires all cases be covered (no fallthrough) so I've refactored so that they aren't nested any more.

## Motivation and Context
Fix the exception thrown in this file.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Generators run locally and the failing ability generates cooldown questions successfully now.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.