### PR TITLE
Delay responses to answer requests for currently active questions

### DIFF
--- a/ShopkeepersQuiz.Api/Controllers/QuestionsController.cs
+++ b/ShopkeepersQuiz.Api/Controllers/QuestionsController.cs
@@ -34,9 +34,9 @@ namespace ShopkeepersQuiz.Api.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public IActionResult GetAnswerForQueueEntry(Guid queueEntryId)
+        public async Task<IActionResult> GetAnswerForQueueEntry(Guid queueEntryId)
         {
-            var result = _questionService.GetPreviousQueueEntryAnswer(queueEntryId);
+            var result = await _questionService.GetPreviousQueueEntryAnswer(queueEntryId);
 
             return result.Match<IActionResult>(
                 answerDto => Ok(answerDto),

--- a/ShopkeepersQuiz.Api/Services/Questions/IQuestionService.cs
+++ b/ShopkeepersQuiz.Api/Services/Questions/IQuestionService.cs
@@ -20,6 +20,6 @@ namespace ShopkeepersQuiz.Api.Services.Questions
 		/// Gets the correct <see cref="AnswerDto"/> for a previous <see cref="QueueEntry"/>.
 		/// </summary>
 		/// <param name="queueEntryId">The ID of the <see cref="QueueEntry"/>.</param>
-		public OneOf<AnswerDto, NotFound, AnswerNotAvailableYet> GetPreviousQueueEntryAnswer(Guid queueEntryId);
+		public ValueTask<OneOf<AnswerDto, NotFound, AnswerNotAvailableYet>> GetPreviousQueueEntryAnswer(Guid queueEntryId);
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
The API now holds out on responding to a request for a question answer if that question is currently active, rather than responding instantly to say "answer not available yet".

## Motivation and Context
This allows clients to immediately request the answer to the question as soon as the user chooses an answer to the question, meaning that when the time comes to reveal the answer there isn't a delay in waiting for a network request to complete, which improves UX. It also means we don't accidentally DDoS the server by having all clients make a request for the answer at the same time, which should slightly improve the performance and scalability of the API.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Tested locally using Swagger.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.