### PR TITLE
Fix Gamepedia scraper due to updated HTML breaking XPath

### DIFF
--- a/ShopkeepersQuiz.Api/Services/Scrapers/GamepediaScraper.cs
+++ b/ShopkeepersQuiz.Api/Services/Scrapers/GamepediaScraper.cs
@@ -18,8 +18,8 @@ namespace ShopkeepersQuiz.Api.Services.Scrapers
 	/// </summary>
 	public class GamepediaScraper : IScraper
 	{
-		const string BaseUrl = @"https://dota2.gamepedia.com";
-		const string HeroesListUrl = @"https://dota2.gamepedia.com/Heroes";
+		const string BaseUrl = @"https://dota2.fandom.com/wiki/";
+		const string HeroesListUrl = @"https://dota2.fandom.com/wiki/Heroes";
 
 		private readonly HtmlWeb _web = new HtmlWeb();
 
@@ -79,7 +79,7 @@ namespace ShopkeepersQuiz.Api.Services.Scrapers
 
 			HtmlDocument heroesListHtml = _web.Load(HeroesListUrl);
 
-			HtmlNodeCollection heroAnchorLinkNodes = heroesListHtml.DocumentNode.SelectNodes("//div[@id='bodyContent']//tbody[1]//tr[td]/td/div//a");
+			HtmlNodeCollection heroAnchorLinkNodes = heroesListHtml.DocumentNode.SelectNodes("//div[@id='content']//tbody[1]//tr[td]/td/div//a");
 			if (!(heroAnchorLinkNodes?.Any() ?? false))
 			{
 				throw new NodeNotFoundException("Failed to find any heroes on the hero list at: " + HeroesListUrl);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
Updates the XPath for retrieving the list of heroes so that it works again after the Gamepedia -> Fandom update.

## Motivation and Context
After Gamepedia.com became Fandom.com the HTML of the Heroes page changed slightly, which broke the XPath for finding all of the heroes.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
- Ran locally using docker-compose.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.